### PR TITLE
fix(mapResultCatching): now does not catch `CancellationException` thrown from the `transform` lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased] - TBD
 
+### Fixed
+
+- `Flow.mapResultCatching` now does not catch `CancellationException`
+  thrown from the `transform` lambda.
+
 ## [0.8.1-Beta] - Mar 23, 2024
 
 ### Changed

--- a/src/commonMain/kotlin/com/hoc081098/flowext/results.kt
+++ b/src/commonMain/kotlin/com/hoc081098/flowext/results.kt
@@ -24,6 +24,7 @@
 
 package com.hoc081098.flowext
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -46,7 +47,15 @@ public fun <T> Flow<T>.mapToResult(): Flow<Result<T>> =
  */
 @FlowExtPreview
 public fun <T, R> Flow<Result<T>>.mapResultCatching(transform: suspend (T) -> R): Flow<Result<R>> =
-  map { result -> result.mapCatching { transform(it) } }
+  map { result ->
+    result
+      .mapCatching { transform(it) }
+      .onFailure {
+        if (it is CancellationException) {
+          throw it
+        }
+      }
+  }
 
 /**
  * Maps a [Flow] of [Result]s to a [Flow] of values from successful results.

--- a/src/commonTest/kotlin/com/hoc081098/flowext/utils/BaseTest.kt
+++ b/src/commonTest/kotlin/com/hoc081098/flowext/utils/BaseTest.kt
@@ -76,4 +76,16 @@ suspend inline fun <reified T : Throwable> assertFailsWith(flow: Flow<*>) {
   }
 }
 
+suspend inline fun <reified T : Throwable, R> assertFailsWith(
+  flow: Flow<R>,
+  crossinline collector: (R) -> Unit,
+) {
+  try {
+    flow.collect { collector(it) }
+    fail("Should be unreached")
+  } catch (e: Throwable) {
+    assertTrue(e is T, "Expected exception ${T::class}, but had $e instead")
+  }
+}
+
 suspend fun Flow<Int>.sum() = fold(0) { acc, value -> acc + value }


### PR DESCRIPTION

## Status

**READY**

## Breaking Changes

NO

## Description

fix(mapResultCatching): now does not catch `CancellationException` thrown from the `transform` lambda

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore

## Requirements

- [x] Dump api
- [x] Update README
- [x] Update CHANGELOG
- [x] Add tests
- [x] Add docs
